### PR TITLE
Add SEE ALSO section

### DIFF
--- a/lib/Acme/ProgressBar.pm
+++ b/lib/Acme/ProgressBar.pm
@@ -78,6 +78,10 @@ sub _overprint {
 =for :list
 * allow other divisions of time (other than ten)
 
+=head1 SEE ALSO
+
+L<Term::ProgressBar>, L<Term::ProgressBar::Simple>, L<Progress::Any::Output::TermProgressBarColor>, L<Smart::Comments>
+
 =cut
 
 "48102931829 minutes remaining";


### PR DESCRIPTION
I was adding a SEE ALSO section to [Smart::Comments](https://metacpan.org/pod/Smart::Comments) as part of the [PR Challenge](http://cpan-prc.org/) and noticed that this module doesn't have one. Figured that I already had a basic list of progress bar modules so why not add it here too.
